### PR TITLE
bugfix/resolvables

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 name=onixlabs-corda-core
 group=io.onixlabs
-version=4.0.2
+version=4.0.3
 onixlabs.development.jarsign.keystore=../lib/onixlabs.development.pkcs12
 onixlabs.development.jarsign.password=5891f47942424d2acbe108691fdb5ba258712fca7e4762be4327241ebf3dbfa3

--- a/onixlabs-corda-test-contract/src/main/kotlin/io/onixlabs/corda/test/contract/Customer.kt
+++ b/onixlabs-corda-test-contract/src/main/kotlin/io/onixlabs/corda/test/contract/Customer.kt
@@ -69,8 +69,7 @@ data class Customer(
 
     private class RewardResolver(private val customer: Customer) : AbstractPluralResolvable<Reward>() {
 
-        @Transient
-        override val criteria: QueryCriteria = vaultQuery<Reward> {
+        override val criteria: QueryCriteria get() = vaultQuery<Reward> {
             expression(RewardEntity::owner equalTo customer.owner)
             expression(RewardEntity::customerLinearId equalTo customer.linearId.id)
             expression(RewardEntity::customerExternalId equalTo customer.linearId.externalId)

--- a/onixlabs-corda-test-contract/src/main/kotlin/io/onixlabs/corda/test/contract/Reward.kt
+++ b/onixlabs-corda-test-contract/src/main/kotlin/io/onixlabs/corda/test/contract/Reward.kt
@@ -59,8 +59,7 @@ data class Reward(
 
     private class CustomerResolver(private val reward: Reward) : AbstractSingularResolvable<Customer>() {
 
-        @Transient
-        override val criteria: QueryCriteria = vaultQuery<Customer> {
+        override val criteria: QueryCriteria get() = vaultQuery<Customer> {
             relevancyStatus(Vault.RelevancyStatus.ALL)
             linearIds(reward.customerLinearId)
         }


### PR DESCRIPTION
Replaced `@Transient` annotation with `get()` to criteria fields in resolvable implementations to prevent them being included in serialization.